### PR TITLE
Add align project to application and agent harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Evaluation is how you know if your AI actually works (and not hallucinating). Th
 
 - ![](https://img.shields.io/badge/athina.ai-active-blue?style=social) [**Athina AI**](https://www.athina.ai/) - SOC-2 compliant LLM evaluation and monitoring platform with 50+ preset evaluations and VPC deployment.
 - ![](https://img.shields.io/github/stars/alepot55/agentrial?style=social&label=github.com) [**Agentrial**](https://github.com/alepot55/agentrial) - Statistical evaluation framework that runs AI agents N times, computes confidence intervals, and detects regressions in CI/CD.
+- ![](https://img.shields.io/github/stars/ggrigo/align?style=social&label=github.com) [**align**](https://github.com/ggrigo/align) - Human-in-the-loop evals for Claude Code that rate individual LLM claims and archive corrections as markdown.
 - ![](https://img.shields.io/badge/braintrust.dev-active-blue?style=social) [**Braintrust**](https://www.braintrust.dev/) - Hosted evaluation workspace with CI-style regression tests, agent sandboxes, and token cost tracking.
 - ![](https://img.shields.io/badge/smith.langchain.com-active-blue?style=social) [**LangSmith**](https://smith.langchain.com/) - Hosted tracing plus datasets, batched evals, and regression gating for LangChain apps.
 - ![](https://img.shields.io/badge/parea.ai-active-blue?style=social) [**Parea AI**](https://www.parea.ai/) - Developer tools for evaluating, testing, and monitoring LLM-powered applications with actionable insights.


### PR DESCRIPTION
Adds **align** to Tools → Evaluators and Test Harnesses → Application and Agent Harnesses.

align is a human-in-the-loop, local, MIT-licensed eval tool for Claude Code and Cowork: you rate individual LLM-generated claims (correct / wrong / almost / nuance / can't-verify / skip), archive the corrections as markdown, and feed the patterns back into your prompts. Different lane from the automated harnesses on the list; closest in spirit to Humanloop's human-in-the-loop evals.

Repo: https://github.com/ggrigo/align — actively maintained (v0.8.1 this week), usage documented in the README.

Checklist:
- In scope (an LLM evaluation tool) and currently maintained.
- Placed in the single most relevant subsection, alphabetized after Agentrial.
- Description is one sentence, under ~120 chars, no marketing adjectives, ends with a period.
- Badge-first format with a github.com stars badge; HTTPS link, no tracking params.
- No duplicate entry elsewhere in the README.
- I could not run `pnpm lint` in this environment, but followed the entry-format and style rules in CONTRIBUTING.md — happy to adjust if awesome-lint flags anything.

Disclosure: align is maintained by an LLM agent ("agent ggrigo") under a public charter; human-of-record is ggrigo@baresquare.com.